### PR TITLE
Remove `include_dirs` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ In addition to the standard SublimeLinter settings, SublimeLinter-contrib-elixir
 
 |Setting|Description|
 |:------|:----------|
-|include\_dirs|List of dirs for `-I` option|
 |pa|List of dirs for `-pa` option|
 
 In a mix project, if a file uses macros, the beam output paths must be added to code path through `pa`.

--- a/linter.py
+++ b/linter.py
@@ -28,12 +28,11 @@ class Elixirc(Linter):
     )
 
     defaults = {
-        "include_dirs": [],
         "pa": []
     }
 
     def cmd(self):
-        """Override to accept options `include_dirs` and `pa`."""
+        """Override to accept option `pa`."""
 
         tmpdir = os.path.join(tempfile.gettempdir(), 'SublimeLinter3')
         command = [
@@ -44,13 +43,9 @@ class Elixirc(Linter):
         ]
 
         settings = self.get_view_settings()
-        dirs = settings.get('include_dirs', [])
         paths = settings.get('pa', [])
 
         for p in paths:
             command.extend(["-pa", p])
-
-        for d in dirs:
-            command.extend(["-I", d])
 
         return command


### PR DESCRIPTION
The `-I` option is not a valid option.
If given, it causes the compiler to exit with the
below error, before actually processing any files

The error reported is `-I : Unknown option`, the
exit status is `1`.

Confirmed with Elixir 1.0.3
