### PR TITLE
Redeem `include dirs` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,31 +36,28 @@ In addition to the standard SublimeLinter settings, SublimeLinter-contrib-elixir
 
 |Setting|Description|
 |:------|:----------|
+|include\_dirs|List of dirs for `-r` option|
 |pa|List of dirs for `-pa` option|
 
-In a mix project, if a file uses macros, the beam output paths must be added to code path through `pa`.
+In a mix project:
+* if a file uses macros, the beam output paths must be added to code path through `pa`
+* if external dependencies are used, their paths must be added through `include_dirs`
+* add the above to your **sublime project**'s settings. Example:
 
-You must save the project file in the top directory in the mix project, then edit the project settings to add the `pa` setting such as:
-
-	{
-		"folders":
-		[
-			{
-				"follow_symlinks": true,
-				"path": ".",
-	      		"folder_exclude_patterns": ["_build"],
+```JSON
+	"SublimeLinter": {
+		"linters": {
+			"elixirc": {
+				"pa": ["MIX_ROOT/_build/dev/lib/PROJECT_WITH_MACROS/ebin"],
+				"include_dirs": ["MIX_ROOT/deps"]
 			}
-		],
-	    "SublimeLinter": {
-	        "linters": {
-	            "elixirc": {
-	                "pa": ["${project}/_build/dev/lib/PROJECT_WITH_MACROS/ebin"]
-	            }
-	        }
-	    }
+		}
 	}
+```
 
-`PROJECT_WITH_MACROS` is the project name which contains the macros. List all projects in `pa`. The project file is required to be saved in the top directory, so that `${project}` can be used as the top level directory of the project.
+Where:
+* `MIX_ROOT` is the root dir of your mix project (use `${project}` if your sublime project is saved there)
+* `PROJECT_WITH_MACROS` is the project name which contains the macros. List all projects in `pa`
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ In addition to the standard SublimeLinter settings, SublimeLinter-contrib-elixir
 
 |Setting|Description|
 |:------|:----------|
-|include\_dirs|List of dirs for `-I` option|
 |pa|List of dirs for `-pa` option|
 
 In a mix project, if a file uses macros, the beam output paths must be added to code path through `pa`.

--- a/linter.py
+++ b/linter.py
@@ -28,12 +28,11 @@ class Elixirc(Linter):
     )
 
     defaults = {
-        "include_dirs": [],
         "pa": []
     }
 
     def cmd(self):
-        """Override to accept options `include_dirs` and `pa`."""
+        """Override to accept option `pa`."""
 
         tmpdir = os.path.join(tempfile.gettempdir(), 'SublimeLinter3')
         command = [
@@ -44,13 +43,9 @@ class Elixirc(Linter):
         ]
 
         settings = self.get_view_settings()
-        dirs = settings.get('include_dirs', [])
         paths = settings.get('pa', [])
 
         for p in paths:
             command.extend(["-pa", p])
-
-        for d in dirs:
-            command.extend(["-I", d])
 
         return command

--- a/linter.py
+++ b/linter.py
@@ -63,4 +63,3 @@ class Elixirc(Linter):
                 match = None
 
         return super().split_match(match)
-

--- a/linter.py
+++ b/linter.py
@@ -12,28 +12,21 @@ class Elixirc(Linter):
     syntax = ("elixir")
 
     executable = "elixirc"
-    tempfile_suffix = "ex"
+    tempfile_suffix = "-"
 
-    # Must skip lines in the stack trace such as
-    #
-    #     |    (stdlib) lists.erl:1336: :lists.foreach/2
-    #
-    # because the line number leads to array index out of bound exception.
-    #
-    # Since they all start with 4 spaces, just ignore all lines starting with a space.
     regex = (
-        r"^[^ ].+:(?P<line>\d+):"
+        r"(?:\*+\s\(.+\) )?(?P<filename>.+):(?P<line>\d+):"
         r"(?:(?P<warning>\swarning:\s)|(?P<error>\s))"
         r"(?P<message>.+)"
     )
 
     defaults = {
+        "include_dirs": [],
         "pa": []
     }
 
     def cmd(self):
-        """Override to accept option `pa`."""
-
+        """Override to accept options `include_dirs` and `pa`."""
         tmpdir = os.path.join(tempfile.gettempdir(), 'SublimeLinter3')
         command = [
             self.executable_path,
@@ -43,9 +36,31 @@ class Elixirc(Linter):
         ]
 
         settings = self.get_view_settings()
+        dirs = settings.get('include_dirs', [])
         paths = settings.get('pa', [])
 
         for p in paths:
             command.extend(["-pa", p])
 
+        for d in dirs:
+            command.extend(["-r", "%s/**/*.ex" % d])
+
         return command
+
+    def split_match(self, match):
+        """
+        Return the components of the match.
+
+        We override this because unrelated library files can throw errors,
+        and we only want errors from the linted file.
+
+        """
+        if match:
+            # The linter seems to always change its working
+            # dir to that of the linted given file, so the
+            # reported error will contain a basename only.
+            if match.group('filename') != os.path.basename(self.filename):
+                match = None
+
+        return super().split_match(match)
+


### PR DESCRIPTION
Following the issue described in #1, this PR re-adds `include_dirs` with the following changes:
- each `<dir>` element in the `include_dirs` config now corresponds to a `-r <dir>/**/*.rb` argument
- the linted file is not copied to a temp dir anymore
- errors/warnings are shown only if caused by the currently linted file
