### PR TITLE
Support for mix projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,30 +34,54 @@ For general information on how SublimeLinter works with settings, please see [Se
 
 In addition to the standard SublimeLinter settings, SublimeLinter-contrib-elixirc provides its own settings.
 
-|Setting|Description|
-|:------|:----------|
-|include\_dirs|List of dirs for `-r` option|
-|pa|List of dirs for `-pa` option|
+|Setting     |Description                    |
+|:-----------|:------------------------------|
+|pa          |_(list)_ dirs for `-pa` option |
+|require     |_(list)_ dirs/files to require |
+|mix_project |_(bool)_ use mix for linting   |
 
-In a mix project:
-* if a file uses macros, the beam output paths must be added to code path through `pa`
-* if external dependencies are used, their paths must be added through `include_dirs`
-* add the above to your **sublime project**'s settings. Example:
+### In a mix project:
+* set `chdir` to your mix project's root directory.
+* set `mix_project` to `true`
 
+#### Example:
+In your _.sublime-project_ file:
 ```JSON
-	"SublimeLinter": {
-		"linters": {
-			"elixirc": {
-				"pa": ["MIX_ROOT/_build/dev/lib/PROJECT_WITH_MACROS/ebin"],
-				"include_dirs": ["MIX_ROOT/deps"]
-			}
-		}
-	}
+   "SublimeLinter": {
+      "linters": {
+         "elixirc": {
+            "mix_project": true,
+            "chdir": "PROJECT_ROOT"
+         }
+      }
+   }
 ```
 
 Where:
-* `MIX_ROOT` is the root dir of your mix project (use `${project}` if your sublime project is saved there)
+* `PROJECT_ROOT` is the path to the root your project (use `${project}` if your sublime project is saved there)
+
+### Outside a mix project:
+* if a file uses macros, the beam output paths must be added to code path through `pa`
+* files (or directories) to require prior before linting must be added through `require`. They are required in the given order. Directory contents are traversed alphabetically.
+* add the above to your **sublime project**'s settings.
+
+#### Example
+In your _.sublime-project_ file:
+```JSON
+   "SublimeLinter": {
+      "linters": {
+         "elixirc": {
+            "pa": ["PROJECT_ROOT/_build/dev/lib/PROJECT_WITH_MACROS/ebin"],
+            "require": ["PROJECT_ROOT/deps/DEP1"]
+         }
+      }
+   }
+```
+
+Where:
+* `PROJECT_ROOT` is the path to the root of your project (use `${project}` if your sublime project is saved there)
 * `PROJECT_WITH_MACROS` is the project name which contains the macros. List all projects in `pa`
+* `DEP1` is a directory with files to require. If needed, list specific files first.
 
 
 ## Contributing

--- a/linter.py
+++ b/linter.py
@@ -2,64 +2,183 @@
 
 import tempfile
 import os
-from SublimeLinter.lint import Linter
+import re
+from SublimeLinter.lint import Linter, persist
 
 
 class Elixirc(Linter):
 
-    """Provides an interface to elixirc."""
+    """
+    Provides an interface to elixirc.
+
+    Error formats:
+
+    1) Default errors:
+    |== Compilation error on file {filename} ==
+    |** ({error_name}) {filename}:{line}: {message}
+    |...<trace lines>...
+
+    2) Macro errors:
+    |== Compilation error on file {filename} ==
+    |** ({error_name}) {message}
+    |...<trace lines>...
+
+    3) Warnings:
+    |{filename}:{line}: warning: {message}
+
+
+    In order to cover all cases we need a complex regex.
+    Since a single regex does *not* allow to have several
+    groups with the same name, we introduce custom group
+    names.
+    The group names are then transformed back to the ones
+    expected by the Linter. This is done by overriding
+    the split_match method.
+
+    """
 
     syntax = ("elixir")
-
-    executable = "elixirc"
     tempfile_suffix = "-"
 
     regex = (
-        r"(?:\*+\s\(.+\) )?(?P<filename>.+):(?P<line>\d+):"
-        r"(?:(?P<warning>\swarning:\s)|(?P<error>\s))"
-        r"(?P<message>.+)"
+        r"^(?:== Compilation error on file (?P<file1>.+) ==\n"
+        r"(?:\*+\s\(.+\))?(?:\s[\S].*:(?P<line1>\d+): )?)(?P<msg1>.+)"
+        r"|"
+        r"(?:(?P<file2>.+):(?P<line2>\d+): warning: (?P<msg2>.+))"
+    )
+
+    dummy_regex = re.compile(
+        r"(?P<filename>.+):"
+        r"(?P<line>\d+):"
+        r"(?:(?P<error>error)|(?P<warning>warning)):"
+        r"(?P<message>.+)",
+        re.UNICODE
     )
 
     defaults = {
         "include_dirs": [],
-        "pa": []
+        "pa": [],
+        "mix": False
     }
 
+    multiline = True
+    executable = "elixir"
+
     def cmd(self):
-        """Override to accept options `include_dirs` and `pa`."""
-        tmpdir = os.path.join(tempfile.gettempdir(), 'SublimeLinter3')
-        command = [
-            self.executable_path,
-            '--warnings-as-errors',
-            '--ignore-module-conflict',
-            '-o', tmpdir
-        ]
-
+        """Convert the linter options to command arguments."""
         settings = self.get_view_settings()
-        dirs = settings.get('include_dirs', [])
+        require = settings.get('require', [])
         paths = settings.get('pa', [])
+        mix = settings.get('mix_project', None)
+        command = [self.executable_path]
 
-        for p in paths:
-            command.extend(["-pa", p])
-
-        for d in dirs:
-            command.extend(["-r", "%s/**/*.ex" % d])
+        if mix:
+            command.extend(self.mix_args())
+        else:
+            command.extend(self.regular_args(paths, require))
 
         return command
 
+    def regular_args(self, paths, require):
+        """
+        Build the argument list when mix is not configured.
+
+        * set the compiler outpur into a tmpdir
+        * from the `require` and `pa` config values, build
+          the list of `-pr` and `-pa` command arguments
+
+        """
+        args = [
+            '+elixirc',
+            '-o', os.path.join(tempfile.gettempdir(), 'SublimeLinter3'),
+            '--warnings-as-errors',
+            '--ignore-module-conflict'
+        ]
+
+        for p in paths:
+            args.extend(["-pa", p])
+
+        for i in require:
+            if os.path.isdir(i):
+                args.extend(["-pr", "%s/**/*.ex" % i])
+            else:
+                args.extend(["-pr", i])
+
+        args.extend([self.filename])
+
+        return args
+
+    def mix_args(self):
+        """With mix, we just need to invoke its compile task."""
+        args = [
+            '-S', 'mix', 'compile',
+            '--warnings-as-errors',
+            '--ignore-module-conflict'
+        ]
+
+        return args
+
     def split_match(self, match):
         """
-        Return the components of the match.
+        Pre-process the matchObject before passing it upstream.
 
-        We override this because unrelated library files can throw errors,
-        and we only want errors from the linted file.
+        Several reasons for this:
+          * unrelated library files can throw errors, and
+            we only want errors from the linted file.
+          * our regex contains more than just the basic
+            capture groups (filename, line, message, etc.)
+            but we still need to pass a match object that
+            contains the above groups upstream.
+          * Line is not reported for some macro errors
 
         """
-        if match:
-            # The linter seems to always change its working
-            # dir to that of the linted given file, so the
-            # reported error will contain a basename only.
-            if match.group('filename') != os.path.basename(self.filename):
-                match = None
+        dummy_match = None
 
-        return super().split_match(match)
+        if match:
+            captures = match.groupdict()
+            dummy_string = self.build_dummy_string(captures)
+            dummy_match = re.match(self.dummy_regex, dummy_string)
+
+        if dummy_match:
+            filename = os.path.join(self.chdir, dummy_match.group('filename'))
+
+            if self.filename != filename:
+                persist.debug(
+                    "Ignore error from %s (linted file: %s)" %
+                    (filename, self.filename)
+                )
+
+                dummy_match = None
+
+        return super().split_match(dummy_match)
+
+    def build_dummy_string(self, captures):
+        """
+        Build a string to be matched against self.dummy_regex.
+
+        It is used to ensure that a matchObject with the
+        appropriate group names is passed upstream.
+
+        Returns a string with the following format:
+        {filename}:{line}:{error_type}:{message}
+
+        """
+        if captures['file1'] is not None:
+            dummy_str = '%s:%s:%s:%s' % (
+                captures['file1'],
+                captures['line1'] or 0,
+                'error',
+                captures['msg1']
+            )
+        elif captures['file2'] is not None:
+            dummy_str = "%s:%s:%s:%s" % (
+                captures['file2'],
+                captures['line2'] or 0,
+                'warning',
+                captures['msg2']
+            )
+        else:
+            dummy_str = ""
+
+        persist.debug("Dummy string: %s" % self.filename)
+        return dummy_str


### PR DESCRIPTION
Improvements:
- new configuration value, `mix_project` (Boolean).
  When set to `true`, linting will be done by invoking `mix compile`,
  which takes care of all project dependencies. [1]
  When set to `false` (the default), the old behavior applies.
- call `elixir` instead of `elixirc`. Then, via CLI arguments, call
  either `elixirc` or `mix compile`, depending on the value of the
  `mix_project` configuration parameter. [2]
- Improve error parsing (at the cost of increased complexity).
- Rename the `include_dirs` config option to `require`
- Improve the `require` option so that it now accepts _both_ dirs and
  files. This resolves the issue of files always being required in
  an alphabetical order, resulting in errors during import.
- Improve the `require` option so that it now uses `-pr`, which
  requires the files in parallel, resulting in improved lint times.

**Notes**:

[1] Since we are now interfacing `elixir` instead of `elixirc`,
    do you think that it makes sense to rename the entire plugin from
    `SubimeLinter-contrib-elixirc` to `SublimeLinter-contrib-elixir` ?

[2] This _depends_ on [SublimeLinter/SublimeLinter3#325](https://github.com/SublimeLinter/SublimeLinter3/pull/325), which adds
    a `chdir` option to SublimeLinter3 -- required since mix does not
    work unless invoked from the project's root dir.
