### PR TITLE
Remove deprecated property for Sublime 4

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -106,7 +106,6 @@ class Elixirc(Linter):
 
     """
 
-    syntax = ("elixir")
     tempfile_suffix = "-"
 
     regex_parts = (
@@ -144,7 +143,8 @@ class Elixirc(Linter):
     defaults = {
         "include_dirs": [],
         "pa": [],
-        "mix": False
+        "mix": False,
+        "selector": "source.ex - meta.attribute-with-value, source.exs, source.eex"
     }
 
     #


### PR DESCRIPTION
The `syntax` property is deprecated in favor of the `defaults:{'selector'}` property. [Source reference](http://www.sublimelinter.com/en/stable/linter_settings.html#selector)